### PR TITLE
Add ignoreUrl options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ ELASTIC_APM_LOG_LEVEL
 ELASTIC_APM_CAPTURE_BODY
 # Capture apm error log stack traces. Possible options are: never, messages, always
 ELASTIC_APM_CAPTURE_ERROR_LOG_STACK_TRACES
-# Set this option to true to use the URL path as the transaction name if no other route could be determined. 
+# Set this option to true to use the URL path as the transaction name if no other route could be determined.
 ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME
+# Set this option to ignore specific URLs from being captured as transactions. The value is array of strings. (Ex. ['/status', '/products/*'])
+ELASTIC_APM_TRANSACTION_IGNORE_URLS
 ```

--- a/lib/start.ts
+++ b/lib/start.ts
@@ -72,5 +72,14 @@ if (process.env.ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME) {
     process.env.ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME === 'true';
 }
 
+if (process.env.ELASTIC_APM_TRANSACTION_IGNORE_URLS) {
+  const ignoreUrls = JSON.parse(
+    process.env.ELASTIC_APM_TRANSACTION_IGNORE_URLS
+  );
+  if (Array.isArray(ignoreUrls)) {
+    options['ignoreUrls'] = ignoreUrls;
+  }
+}
+
 const apm: apmAgent.Agent = apmAgent.start(options);
 export { apm };


### PR DESCRIPTION
This PR add in start of apm the ignoreUrl option using the original environment variable `ELASTIC_APM_TRANSACTION_IGNORE_URLS`. This variable need to be an array of strings.